### PR TITLE
Fixes incorrect documentation on where behavior scripts should live.

### DIFF
--- a/docs/building/scripting.md
+++ b/docs/building/scripting.md
@@ -53,10 +53,10 @@ bundles/my-bundle/
     limbo/
     ...
   behaviors/
-    npcs/
+    npc/
       aggro.js
-    items/
-    rooms/
+    item/
+    room/
     area/
 ```
 


### PR DESCRIPTION
# Issue

Ranvier docs seem to specify that the following directories are where behavioral scripts live:

```
/bundle-abc
  /behaviors/
    /items
    /npcs
    /area
    /rooms
```

This is not correct as behavioral scripts use singular noun subdirectories, unlike custom scripts which use plural.

# Fix

As below
